### PR TITLE
Sprucing up identifier output

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The repo will be archived in an item at url containing the repository name and t
 
 The git repo bundle will be available at url:
 
-    https://archive.org/download/github.com-<GITHUBUSER>-<RESPOSITORY>_-_<DATE-LAST-PUSH>/<BUNDLENAME>.bundle
+    https://archive.org/download/github-<GITHUBUSER>-<RESPOSITORY>_-_<DATE-LAST-PUSH>/<BUNDLENAME>.bundle
 
 ## Restore an archived github repository
 

--- a/iagitup.py
+++ b/iagitup.py
@@ -161,7 +161,7 @@ def upload_ia(gh_repo_folder, gh_repo_data, custom_meta=None):
 
     # inizializing the internet archive item name
     # here we set the ia identifier
-    itemname = '%s-%s_-_%s' % ('github.com', repo_name, pushed_date)
+    itemname = '%s-%s_-_%s' % ('github', repo_name, pushed_date)
     title = '%s' % (itemname)
 
     #initializing the main metadata


### PR DESCRIPTION
- Removed TLD from identifier since only one site is currently supported, so no need to specify `.com`
- Updated README.md to reflect change.