### PR TITLE
README: minor adjustments to install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,20 @@ to give the script upload privileges.
 
 Configure `internetarchive` with your Internet Archive login details:
 
-        ia configure
+    ia configure
 
 
 ## Usage
 
-        ./iagitup.py [-h] <github_repo_url>
+    ./iagitup.py [-h] <github_repo_url>
 
 You can add also custom metadata:
 
-        ./iagitup.py [-h] --metadata=<key:value,key2:val2> <github_repo_url> 
+    ./iagitup.py [-h] --metadata=<key:value,key2:val2> <github_repo_url> 
 
 Example:
 
-        ./iagitup.py https://github.com/<GITHUBUSER>/<RESPOSITORY>
+    ./iagitup.py https://github.com/<GITHUBUSER>/<RESPOSITORY>
 
 The script downloads the git repo from github, creates a git bundle and uploads it on the Internet Archive.
 
@@ -61,8 +61,7 @@ Download the bundle file, form the archived item:
     https://archive.org/download/.../<ARCHIVED_REPO>.bundle
 Just download the _.bundle_ file and run:
 
-     git clone file.bundle 
-
+    git clone file.bundle 
 
 
 ## License (GPLv3)

--- a/README.md
+++ b/README.md
@@ -9,23 +9,23 @@ The upload is enriched with metadata from the github api and the README.md
 
 Prerequisites (with Debian or Ubuntu):
 
-    sudo apt update 
-    sudo apt install python python-dev python-virtualenv libffi-dev libssl-dev git
+    sudo apt update && sudo apt install python python-dev python-virtualenv libffi-dev libssl-dev git
 
 Clone the repo and create the virtualenv and all things...
 
-    git clone https://github.com/gdamdam/iagitup.git ; cd iagitup
+    git clone https://github.com/gdamdam/iagitup.git && cd iagitup
 
 Create the virtualenv:
 
-    virtualenv venv
-    source venv/bin/activate
+    virtualenv venv && source venv/bin/activate
 
 Install the requirements:
 
-    pip install -r requirements.txt
+    pip install --user -r requirements.txt
 
-If you don't already have an Internet Archive account, [register for one](https://archive.org/account/login.createaccount.php) to give the script upload privileges.
+If you don't already have an Internet Archive account,
+[register for one](https://archive.org/account/login.createaccount.php)
+to give the script upload privileges.
 
 Configure `internetarchive` with your Internet Archive login details:
 


### PR DESCRIPTION
These changes make following along the installation smoother, especially when not running as root.

Using `&&` allows errors to halt the execution of further commands.

Adding `--user` to the pip installation command prevents the need for root permissions.