### PR TITLE
Fix year type in metadata dictionary

### DIFF
--- a/iagitup/iagitup.py
+++ b/iagitup/iagitup.py
@@ -180,7 +180,7 @@ def upload_ia(gh_repo_folder, gh_repo_data, custom_meta=None):
     title = '%s' % (itemname)
 
     #initializing the main metadata
-    meta = dict(mediatype=mediatype, creator=uploader_name, collection=collection, title=title, year=year, date=date, \
+    meta = dict(mediatype=mediatype, creator=uploader_name, collection=collection, title=title, year=str(year), date=date, \
            subject=subject, uploaded_with=uploader, originalurl=originalurl, pushed_date=raw_pushed_date, description=description)
 
     # override default metadata with any supplemental metadata provided.


### PR DESCRIPTION
Fix error `Header part (2026) from ('x-archive-meta00-year', 2026) must be of type str or bytes, not <class 'int'>`  when uploading.